### PR TITLE
【bugfix】人物の新規登録時に例外が発生する

### DIFF
--- a/lib/presentation/person_edit_page/notifier/person_edit_page_notifier.dart
+++ b/lib/presentation/person_edit_page/notifier/person_edit_page_notifier.dart
@@ -11,7 +11,6 @@ import 'package:friend_list/infrastructure/local_database/person/contact/contact
 import 'package:friend_list/infrastructure/shared_preferences/app_shared_preferences.dart';
 import 'package:friend_list/presentation/app_router.dart';
 import 'package:friend_list/presentation/person_edit_page/state/person_edit_page_state.dart';
-import 'package:friend_list/presentation/person_list_page/provider/person_list_page_provider.dart';
 
 class PersonEditPageNotifier extends StateNotifier<PersonEditPageState> {
   @protected
@@ -28,7 +27,6 @@ class PersonEditPageNotifier extends StateNotifier<PersonEditPageState> {
   Future<void> onPressedSave() async {
     if (state.validate()) {
       await ref.read(personRepository).save(state.person);
-      ref.invalidate(personListPageProvider);
       ref.read(router).pop(state.person);
     }
   }

--- a/lib/presentation/person_list_page/notifier/person_list_page_notifier.dart
+++ b/lib/presentation/person_list_page/notifier/person_list_page_notifier.dart
@@ -46,7 +46,7 @@ class PersonListPageNotifier
     if (res == null) {
       return;
     }
-    state = ref.refresh(personListPageProvider);
+    ref.invalidate(personListPageProvider);
   }
 
   Future<void> onPressedPersonListTile(Person person) async {


### PR DESCRIPTION
## 原因
`state = ref.refresh`と記述していたが、refreshのタイミングで一度stateの`dispose`が行われ、もとのstateにアクセスできない状態になるため。`state was disposed`となっていた。

## 対応
同じページのstate更新のため、そもそも`refresh`ではなく`invalidate`で事足りる